### PR TITLE
fixes the set of keywords

### DIFF
--- a/bap-mode.el
+++ b/bap-mode.el
@@ -32,6 +32,7 @@
     "when"
     "call"
     "return"
+    "noreturn"
     "high"
     "low"
     "in"
@@ -46,11 +47,10 @@
     "pad"
     "extend"
     "el"
-    "FS_BASE"
+    "be"
+    "phi"
+    "ite"
     "unknown"
-    "undefined"
-    "after"
-    "is"
     "interrupt"))
 
 (defconst bap-defs


### PR DESCRIPTION
# Removed
- `FS_BASE` is removed as it is just a variable name (specific to x86)
- `is`, `undefined`, `after` - those are parts of a human-readable comment in the `unknown` expression
# Added 
- `be` for big-endian
- `phi` for phi-nodes
- `ite` the new syntax for the revised `ite` expressions
- `noreturn` for noreturn calls