### PR TITLE
Add package dependency header

### DIFF
--- a/bap-mode.el
+++ b/bap-mode.el
@@ -10,6 +10,7 @@
 ;; Version: 0.2
 ;; Keywords: languages
 ;; Homepage: https://github.com/fkie-cad/bap-mode
+;; Package-Requires: ((helm-core "3.6.0"))
 ;;
 ;; This file is not part of GNU Emacs.
 ;;


### PR DESCRIPTION
It is necessary for installing dependencies by package manager.